### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,5 @@ module "nlb" {
     eu-west-1a = cidrsubnet(aws_vpc.this, 8, 0)
     eu-west-1b = cidrsubnet(aws_vpc.this, 8, 1)
   }
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "nlb" {
-  source  = "./.."
+  source = "./.."
 
   name = "example"
 

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -14,7 +14,7 @@ module "nlb" {
     local-b = "10.0.1.0/24"
   }
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,10 @@ module "subnets" {
   availability_zone = each.key
   cidr_block        = each.value
 
-  tags = var.tags
+  route_table_tags = var.route_table_tags
+  subnet_tags      = var.subnet_tags
+
+  default_tags = var.default_tags
 }
 
 # NLB
@@ -23,7 +26,7 @@ resource "aws_lb" "this" {
   internal = true
   subnets  = values(module.subnets)[*].this.id
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.lb_tags)
 }
 
 # API Gateway VPC Link
@@ -32,5 +35,5 @@ resource "aws_api_gateway_vpc_link" "this" {
   name        = var.name
   target_arns = [aws_lb.this.arn]
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.api_gateway_vpc_link_tags)
 }

--- a/subnet/main.tf
+++ b/subnet/main.tf
@@ -8,7 +8,7 @@ resource "aws_subnet" "this" {
 
   tags = merge({
     Name = "private - ${var.name} - ${var.availability_zone}"
-  }, var.tags)
+  }, var.default_tags, var.subnet_tags)
 }
 
 resource "aws_route_table" "this" {
@@ -16,7 +16,7 @@ resource "aws_route_table" "this" {
 
   tags = merge({
     Name = "private - ${var.name} - ${var.availability_zone}"
-  }, var.tags)
+  }, var.default_tags, var.route_table_tags)
 }
 
 resource "aws_route_table_association" "this" {

--- a/subnet/variables.tf
+++ b/subnet/variables.tf
@@ -1,31 +1,60 @@
 variable "availability_zone" {
-  description = "Availability zone of the subnet"
-
   type = string
+
+  description = <<EOS
+Availability zone of the subnet.
+EOS
 }
 
 variable "cidr_block" {
-  description = "Subnet CIDR"
-
   type = string
+
+  description = <<EOS
+Subnet CIDR.
+EOS
+}
+
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
 }
 
 variable "name" {
-  description = "Name of the NLB"
-
   type = string
+
+  description = <<EOS
+Name of the NLB.
+EOS
 }
 
-variable "tags" {
-  description = "Map of tags to assign to all resources supporting tags (in addition to the `Name` tag)"
+variable "route_table_tags" {
+  type    = map(string)
+  default = {}
 
-  type = map(string)
+  description = <<EOS
+Map of tags assigned to the route table.
+EOS
+}
+
+variable "subnet_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the subnet.
+EOS
 }
 
 variable "vpc" {
-  description = "VPC where the subnet will be created"
-
   type = object({
     id = string
   })
+
+  description = <<EOS
+VPC where the subnet will be created.
+EOS
 }

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ Map of tags assigned to all AWS resources created by this module.
 EOS
 }
 
-varialbe "lb_tags" {
+variable "lb_tags" {
   type    = map(string)
   default = {}
 
@@ -41,7 +41,7 @@ Name of the NLB.
 EOS
 }
 
-varialbe "route_table_tags" {
+variable "route_table_tags" {
   type    = map(string)
   default = {}
 
@@ -50,7 +50,7 @@ Map of tags assigned to the route tables.
 EOS
 }
 
-varialbe "subnet_tags" {
+variable "subnet_tags" {
   type    = map(string)
   default = {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,26 +1,70 @@
-variable "cidr_blocks" {
-  description = "Map of subnet CIDRs by availability zone used by the NLB"
+variable "api_gateway_vpc_link_tags" {
+  type    = map(string)
+  default = {}
 
+  description = <<EOS
+Map of tags assigned to the API Gateway VPC Link.
+EOS
+}
+
+variable "cidr_blocks" {
   type = map(string)
+
+  description = <<EOS
+Map of subnet CIDRs by availability zone used by the NLB.
+EOS
+}
+
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
+varialbe "lb_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the NLB.
+EOS
 }
 
 variable "name" {
-  description = "Name of the NLB"
-
   type = string
+
+  description = <<EOS
+Name of the NLB.
+EOS
 }
 
-variable "tags" {
-  description = "Map of tags to assign to all resources supporting tags (in addition to the `Name` tag)"
-
+varialbe "route_table_tags" {
   type    = map(string)
   default = {}
+
+  description = <<EOS
+Map of tags assigned to the route tables.
+EOS
+}
+
+varialbe "subnet_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the subnets.
+EOS
 }
 
 variable "vpc" {
-  description = "VPC where the NLB and the subnets will be created"
-
   type = object({
     id = string
   })
+
+  description = <<EOS
+VPC where the NLB and the subnets will be created.
+EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.