### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,5 @@ module "nlb" {
     eu-west-1a = cidrsubnet(aws_vpc.this, 8, 0)
     eu-west-1b = cidrsubnet(aws_vpc.this, 8, 1)
   }
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -14,7 +14,7 @@ module "nlb" {
     local-b = "10.0.1.0/24"
   }
 
-  tags = {
+  default_tags = {
     app = "example"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "subnets" {
   availability_zone = each.key
   cidr_block        = each.value
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 # NLB
@@ -23,7 +23,7 @@ resource "aws_lb" "this" {
   internal = true
   subnets  = values(module.subnets)[*].this.id
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 # API Gateway VPC Link
@@ -32,5 +32,5 @@ resource "aws_api_gateway_vpc_link" "this" {
   name        = var.name
   target_arns = [aws_lb.this.arn]
 
-  tags = var.tags
+  tags = var.default_tags
 }

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "subnets" {
   availability_zone = each.key
   cidr_block        = each.value
 
-  tags = var.default_tags
+  default_tags = var.default_tags
 }
 
 # NLB

--- a/subnet/main.tf
+++ b/subnet/main.tf
@@ -8,7 +8,7 @@ resource "aws_subnet" "this" {
 
   tags = merge({
     Name = "private - ${var.name} - ${var.availability_zone}"
-  }, var.tags)
+  }, var.default_tags)
 }
 
 resource "aws_route_table" "this" {
@@ -16,7 +16,7 @@ resource "aws_route_table" "this" {
 
   tags = merge({
     Name = "private - ${var.name} - ${var.availability_zone}"
-  }, var.tags)
+  }, var.default_tags)
 }
 
 resource "aws_route_table_association" "this" {

--- a/subnet/variables.tf
+++ b/subnet/variables.tf
@@ -14,19 +14,19 @@ Subnet CIDR.
 EOS
 }
 
+variable "default_tags" {
+  type = map(string)
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "name" {
   type = string
 
   description = <<EOS
 Name of the NLB.
-EOS
-}
-
-variable "tags" {
-  type = map(string)
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }
 

--- a/subnet/variables.tf
+++ b/subnet/variables.tf
@@ -15,7 +15,8 @@ EOS
 }
 
 variable "default_tags" {
-  type = map(string)
+  type    = map(string)
+  default = {}
 
   description = <<EOS
 Map of tags assigned to all AWS resources created by this module.

--- a/variables.tf
+++ b/variables.tf
@@ -6,20 +6,20 @@ Map of subnet CIDRs by availability zone used by the NLB.
 EOS
 }
 
-variable "name" {
-  type = string
-
-  description = <<EOS
-Name of the NLB.
-EOS
-}
-
-variable "tags" {
+variable "default_tags" {
   type    = map(string)
   default = {}
 
   description = <<EOS
 Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
+variable "name" {
+  type = string
+
+  description = <<EOS
+Name of the NLB.
 EOS
 }
 


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.